### PR TITLE
feat: add zstd compression support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,7 @@ linters:
             - github.com/aws/aws-sdk-go-v2
             - github.com/rs/zerolog
             - github.com/jedib0t/go-pretty/v6/table
+            - github.com/klauspost/compress
           deny:
             - pkg: github.com/backup-blob/zfs-backup-blob/internal/repository
               desc: not allowed

--- a/cmd/command/shared/container.go
+++ b/cmd/command/shared/container.go
@@ -85,10 +85,11 @@ func LoadDeps(configPath, logLevel string) container.Container {
 		return driver.NewConfigDriver(&config.LoadParams{
 			ConfigReader: configReader,
 			StageMapping: map[string]func() config.ConfigStage{
-				"s3":       config.NewS3Config,
-				"crypt":    config.NewCryptConfig,
-				"zfs":      config.NewZfsConfig,
-				"throttle": config.NewThrottleConfig,
+				"s3":        config.NewS3Config,
+				"crypt":     config.NewCryptConfig,
+				"compress":  config.NewCompressConfig,
+				"zfs":       config.NewZfsConfig,
+				"throttle":  config.NewThrottleConfig,
 			},
 			StorageDriverFunc: func(s *config.S3Config) (domain.StorageDriver, error) {
 				return driver.NewS3StorageFromConfig(s, logger)
@@ -102,6 +103,8 @@ func LoadDeps(configPath, logLevel string) container.Container {
 					return driver.NewThrottle(v)
 				case *config.CryptConfig:
 					return driver.NewCrypt(v)
+				case *config.CompressConfig:
+					return driver.NewCompress(v)
 				default:
 					return nil
 				}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golobby/container/v3 v3.3.2
 	github.com/jedib0t/go-pretty/v6 v6.7.8
+	github.com/klauspost/compress v1.18.4
 	github.com/rs/zerolog v1.34.0
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cobra v1.10.2
@@ -72,7 +73,6 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/domain/config/compress.go
+++ b/internal/domain/config/compress.go
@@ -1,0 +1,21 @@
+package config
+
+type CompressConfig struct {
+	T        string `yaml:"type" validate:"required"`
+	Remote_  string `yaml:"remote" validate:"required"`
+	Level    int    `yaml:"level" validate:"min=1,max=22"`
+}
+
+func NewCompressConfig() ConfigStage {
+	return &CompressConfig{
+		Level: 3, // default level: good balance of speed/compression
+	}
+}
+
+func (c *CompressConfig) Type() ConfigType {
+	return Middleware
+}
+
+func (c *CompressConfig) Remote() string {
+	return c.Remote_
+}

--- a/internal/domain/config/compress.go
+++ b/internal/domain/config/compress.go
@@ -1,21 +1,28 @@
 package config
 
+// DefaultCompressLevel is the default compression level (balance of speed/ratio).
+const DefaultCompressLevel = 3
+
+// CompressConfig holds compression settings.
 type CompressConfig struct {
-	T        string `yaml:"type" validate:"required"`
-	Remote_  string `yaml:"remote" validate:"required"`
-	Level    int    `yaml:"level" validate:"min=1,max=22"`
+	T       string `yaml:"type" validate:"required"`
+	Remote_ string `yaml:"remote" validate:"required"`
+	Level   int    `yaml:"level" validate:"min=1,max=22"`
 }
 
+// NewCompressConfig creates a new compress config with default level.
 func NewCompressConfig() ConfigStage {
 	return &CompressConfig{
-		Level: 3, // default level: good balance of speed/compression
+		Level: DefaultCompressLevel,
 	}
 }
 
+// Type returns the config type for this stage.
 func (c *CompressConfig) Type() ConfigType {
 	return Middleware
 }
 
+// Remote returns the remote stage name.
 func (c *CompressConfig) Remote() string {
 	return c.Remote_
 }

--- a/internal/domain/config/compress_test.go
+++ b/internal/domain/config/compress_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestNewCompressConfig(t *testing.T) {
+	conf := NewCompressConfig()
+	if conf == nil {
+		t.Fatal("expected non-nil config")
+	}
+	
+	cc, ok := conf.(*CompressConfig)
+	if !ok {
+		t.Fatal("expected *CompressConfig type")
+	}
+	
+	// Check default level
+	if cc.Level != 3 {
+		t.Errorf("expected default level 3, got %d", cc.Level)
+	}
+	
+	// Check type is Middleware
+	if cc.Type() != Middleware {
+		t.Errorf("expected type Middleware, got %v", cc.Type())
+	}
+}
+
+func TestCompressConfig_Type(t *testing.T) {
+	conf := &CompressConfig{}
+	if conf.Type() != Middleware {
+		t.Errorf("expected Middleware type")
+	}
+}
+
+func TestCompressConfig_Remote(t *testing.T) {
+	conf := &CompressConfig{
+		Remote_: "s3-storage",
+	}
+	if conf.Remote() != "s3-storage" {
+		t.Errorf("expected remote 's3-storage', got '%s'", conf.Remote())
+	}
+}

--- a/internal/domain/config/crypto.go
+++ b/internal/domain/config/crypto.go
@@ -3,7 +3,7 @@ package config
 type CryptConfig struct {
 	t        string `yaml:"type" validate:"required"`
 	Remote_  string `yaml:"remote" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
+	Password string `yaml:"password" validate:"required"` //nolint:gosec // configuration field for encryption password
 }
 
 func NewCryptConfig() ConfigStage {

--- a/internal/domain/config/s3.go
+++ b/internal/domain/config/s3.go
@@ -7,8 +7,8 @@ type S3Config struct {
 	UsePathStyle   bool   `yaml:"usePathStyle"`
 	BaseEndpoint   string `yaml:"baseEndpoint"`
 	Prefix         string `yaml:"prefix"`
-	AccessKey      string `yaml:"accessKey"`
-	AccessSecret   string `yaml:"accessSecret"`
+	AccessKey      string `yaml:"accessKey"` //nolint:gosec // AWS credential configuration field
+	AccessSecret   string `yaml:"accessSecret"` //nolint:gosec // AWS credential configuration field
 	MaxRetries     int    `yaml:"maxRetries"`
 	UploadPartSize int    `yaml:"uploadPartSize"`
 }

--- a/internal/driver/compress.go
+++ b/internal/driver/compress.go
@@ -10,6 +10,7 @@ import (
 )
 
 // speed thresholds for compression levels.
+// These map user-friendly levels to zstd encoder speeds.
 const (
 	fastestThreshold = 2
 	defaultThreshold = 5

--- a/internal/driver/compress.go
+++ b/internal/driver/compress.go
@@ -1,0 +1,105 @@
+package driver
+
+import (
+	"fmt"
+	"github.com/backup-blob/zfs-backup-blob/internal/domain"
+	"github.com/backup-blob/zfs-backup-blob/internal/domain/config"
+	"github.com/klauspost/compress/zstd"
+	"io"
+)
+
+type CompressDriver struct {
+	Conf *config.CompressConfig
+}
+
+func NewCompress(conf *config.CompressConfig) domain.Middleware {
+	return &CompressDriver{Conf: conf}
+}
+
+func (cd *CompressDriver) encoderLevel() zstd.EncoderLevel {
+	// Map 1-22 to zstd levels
+	switch {
+	case cd.Conf.Level <= 2:
+		return zstd.SpeedFastest
+	case cd.Conf.Level <= 5:
+		return zstd.SpeedDefault
+	case cd.Conf.Level <= 9:
+		return zstd.SpeedBetterCompression
+	default:
+		return zstd.SpeedBestCompression
+	}
+}
+
+// Read wraps the reader with compression (used during backup)
+// When backing up: zfs send output -> Read(compress) -> upload
+func (cd *CompressDriver) Read(r io.Reader) (rp io.Reader, err error) {
+	pr, pw := io.Pipe()
+	
+	go func() {
+		encoder, err := zstd.NewWriter(pw, zstd.WithEncoderLevel(cd.encoderLevel()))
+		if err != nil {
+			pw.CloseWithError(fmt.Errorf("failed to create zstd encoder: %w", err))
+			return
+		}
+		
+		_, copyErr := io.Copy(encoder, r)
+		closeErr := encoder.Close()
+		
+		if copyErr != nil {
+			pw.CloseWithError(copyErr)
+		} else if closeErr != nil {
+			pw.CloseWithError(closeErr)
+		} else {
+			pw.Close()
+		}
+	}()
+	
+	return pr, nil
+}
+
+// decompressWriter wraps the pipe writer and waits for decompression to complete
+type decompressWriter struct {
+	pw     *io.PipeWriter
+	done   chan error
+	closed bool
+}
+
+func (d *decompressWriter) Write(p []byte) (n int, err error) {
+	return d.pw.Write(p)
+}
+
+func (d *decompressWriter) Close() error {
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	err := d.pw.Close()
+	if err != nil {
+		return err
+	}
+	// Wait for decompression to complete
+	return <-d.done
+}
+
+// Write wraps the writer with decompression (used during restore)
+// When restoring: download -> Write(decompress) -> zfs receive
+func (cd *CompressDriver) Write(w io.Writer) (wp io.Writer, err error) {
+	pr, pw := io.Pipe()
+	done := make(chan error, 1)
+	
+	go func() {
+		decoder, err := zstd.NewReader(pr)
+		if err != nil {
+			pr.CloseWithError(fmt.Errorf("failed to create zstd decoder: %w", err))
+			done <- err
+			return
+		}
+		defer decoder.Close()
+		
+		_, copyErr := io.Copy(w, decoder)
+		pr.CloseWithError(copyErr)
+		done <- copyErr
+	}()
+	
+	return &decompressWriter{pw: pw, done: done}, nil
+}

--- a/internal/driver/compress.go
+++ b/internal/driver/compress.go
@@ -2,22 +2,25 @@ package driver
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/backup-blob/zfs-backup-blob/internal/domain"
 	"github.com/backup-blob/zfs-backup-blob/internal/domain/config"
 	"github.com/klauspost/compress/zstd"
-	"io"
 )
 
+// CompressDriver implements compression middleware using zstd.
 type CompressDriver struct {
 	Conf *config.CompressConfig
 }
 
+// NewCompress creates a new compression middleware.
 func NewCompress(conf *config.CompressConfig) domain.Middleware {
 	return &CompressDriver{Conf: conf}
 }
 
+// encoderLevel maps user level (1-22) to zstd encoder levels.
 func (cd *CompressDriver) encoderLevel() zstd.EncoderLevel {
-	// Map 1-22 to zstd levels
 	switch {
 	case cd.Conf.Level <= 2:
 		return zstd.SpeedFastest
@@ -30,21 +33,21 @@ func (cd *CompressDriver) encoderLevel() zstd.EncoderLevel {
 	}
 }
 
-// Read wraps the reader with compression (used during backup)
-// When backing up: zfs send output -> Read(compress) -> upload
+// Read wraps the reader with compression (used during backup).
+// When backing up: zfs send output -> Read(compress) -> upload.
 func (cd *CompressDriver) Read(r io.Reader) (rp io.Reader, err error) {
 	pr, pw := io.Pipe()
-	
+
 	go func() {
 		encoder, err := zstd.NewWriter(pw, zstd.WithEncoderLevel(cd.encoderLevel()))
 		if err != nil {
 			pw.CloseWithError(fmt.Errorf("failed to create zstd encoder: %w", err))
 			return
 		}
-		
+
 		_, copyErr := io.Copy(encoder, r)
 		closeErr := encoder.Close()
-		
+
 		if copyErr != nil {
 			pw.CloseWithError(copyErr)
 		} else if closeErr != nil {
@@ -53,21 +56,23 @@ func (cd *CompressDriver) Read(r io.Reader) (rp io.Reader, err error) {
 			pw.Close()
 		}
 	}()
-	
+
 	return pr, nil
 }
 
-// decompressWriter wraps the pipe writer and waits for decompression to complete
+// decompressWriter wraps the pipe writer and waits for decompression to complete.
 type decompressWriter struct {
 	pw     *io.PipeWriter
 	done   chan error
 	closed bool
 }
 
+// Write implements io.Writer.
 func (d *decompressWriter) Write(p []byte) (n int, err error) {
 	return d.pw.Write(p)
 }
 
+// Close implements io.Closer and waits for decompression to finish.
 func (d *decompressWriter) Close() error {
 	if d.closed {
 		return nil
@@ -77,16 +82,16 @@ func (d *decompressWriter) Close() error {
 	if err != nil {
 		return err
 	}
-	// Wait for decompression to complete
+	// Wait for decompression to complete.
 	return <-d.done
 }
 
-// Write wraps the writer with decompression (used during restore)
-// When restoring: download -> Write(decompress) -> zfs receive
+// Write wraps the writer with decompression (used during restore).
+// When restoring: download -> Write(decompress) -> zfs receive.
 func (cd *CompressDriver) Write(w io.Writer) (wp io.Writer, err error) {
 	pr, pw := io.Pipe()
 	done := make(chan error, 1)
-	
+
 	go func() {
 		decoder, err := zstd.NewReader(pr)
 		if err != nil {
@@ -95,11 +100,11 @@ func (cd *CompressDriver) Write(w io.Writer) (wp io.Writer, err error) {
 			return
 		}
 		defer decoder.Close()
-		
+
 		_, copyErr := io.Copy(w, decoder)
 		pr.CloseWithError(copyErr)
 		done <- copyErr
 	}()
-	
+
 	return &decompressWriter{pw: pw, done: done}, nil
 }

--- a/internal/driver/compress.go
+++ b/internal/driver/compress.go
@@ -9,6 +9,13 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
+// speed thresholds for compression levels.
+const (
+	fastestThreshold = 2
+	defaultThreshold = 5
+	betterThreshold  = 9
+)
+
 // CompressDriver implements compression middleware using zstd.
 type CompressDriver struct {
 	Conf *config.CompressConfig
@@ -22,11 +29,11 @@ func NewCompress(conf *config.CompressConfig) domain.Middleware {
 // encoderLevel maps user level (1-22) to zstd encoder levels.
 func (cd *CompressDriver) encoderLevel() zstd.EncoderLevel {
 	switch {
-	case cd.Conf.Level <= 2:
+	case cd.Conf.Level <= fastestThreshold:
 		return zstd.SpeedFastest
-	case cd.Conf.Level <= 5:
+	case cd.Conf.Level <= defaultThreshold:
 		return zstd.SpeedDefault
-	case cd.Conf.Level <= 9:
+	case cd.Conf.Level <= betterThreshold:
 		return zstd.SpeedBetterCompression
 	default:
 		return zstd.SpeedBestCompression
@@ -48,11 +55,12 @@ func (cd *CompressDriver) Read(r io.Reader) (rp io.Reader, err error) {
 		_, copyErr := io.Copy(encoder, r)
 		closeErr := encoder.Close()
 
-		if copyErr != nil {
+		switch {
+		case copyErr != nil:
 			pw.CloseWithError(copyErr)
-		} else if closeErr != nil {
+		case closeErr != nil:
 			pw.CloseWithError(closeErr)
-		} else {
+		default:
 			pw.Close()
 		}
 	}()
@@ -77,18 +85,21 @@ func (d *decompressWriter) Close() error {
 	if d.closed {
 		return nil
 	}
+
 	d.closed = true
+
 	err := d.pw.Close()
 	if err != nil {
 		return err
 	}
+
 	// Wait for decompression to complete.
 	return <-d.done
 }
 
 // Write wraps the writer with decompression (used during restore).
 // When restoring: download -> Write(decompress) -> zfs receive.
-func (cd *CompressDriver) Write(w io.Writer) (wp io.Writer, err error) {
+func (cd *CompressDriver) Write(writer io.Writer) (wp io.Writer, err error) {
 	pr, pw := io.Pipe()
 	done := make(chan error, 1)
 
@@ -97,11 +108,13 @@ func (cd *CompressDriver) Write(w io.Writer) (wp io.Writer, err error) {
 		if err != nil {
 			pr.CloseWithError(fmt.Errorf("failed to create zstd decoder: %w", err))
 			done <- err
+
 			return
 		}
+
 		defer decoder.Close()
 
-		_, copyErr := io.Copy(w, decoder)
+		_, copyErr := io.Copy(writer, decoder)
 		pr.CloseWithError(copyErr)
 		done <- copyErr
 	}()

--- a/internal/driver/compress_test.go
+++ b/internal/driver/compress_test.go
@@ -201,10 +201,10 @@ func TestCompressDriver_RoundTrip(t *testing.T) {
 				}
 			}
 			
-			decompressedData := output.Bytes()
-			if !bytes.Equal(decompressedData, tc.data) {
+			result := output.Bytes()
+			if !bytes.Equal(result, tc.data) {
 				t.Errorf("decompressed data doesn't match original (len=%d vs len=%d)",
-					len(decompressedData), len(tc.data))
+					len(result), len(tc.data))
 			}
 		})
 	}

--- a/internal/driver/compress_test.go
+++ b/internal/driver/compress_test.go
@@ -1,0 +1,211 @@
+package driver
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/backup-blob/zfs-backup-blob/internal/domain/config"
+)
+
+func TestNewCompress(t *testing.T) {
+	conf := &config.CompressConfig{
+		Level: 3,
+	}
+	
+	driver := NewCompress(conf)
+	if driver == nil {
+		t.Fatal("expected non-nil driver")
+	}
+	
+	cd, ok := driver.(*CompressDriver)
+	if !ok {
+		t.Fatal("expected *CompressDriver type")
+	}
+	
+	if cd.Conf.Level != 3 {
+		t.Errorf("expected level 3, got %d", cd.Conf.Level)
+	}
+}
+
+func TestCompressDriver_Read(t *testing.T) {
+	testData := []byte("This is test data for compression. " +
+		"It needs to be long enough to actually benefit from compression. " +
+		"Zstd works best with larger chunks of data. " +
+		"Repeating patterns help: abc abc abc abc abc abc abc abc abc abc")
+	
+	conf := &config.CompressConfig{Level: 3}
+	driver := NewCompress(conf)
+	
+	// Create a reader with test data
+	originalReader := bytes.NewReader(testData)
+	
+	// Wrap with compression (this is what happens during backup)
+	compressedReader, err := driver.Read(originalReader)
+	if err != nil {
+		t.Fatalf("failed to create compressed reader: %v", err)
+	}
+	
+	// Read all compressed data
+	compressedData, err := io.ReadAll(compressedReader)
+	if err != nil {
+		t.Fatalf("failed to read compressed data: %v", err)
+	}
+	
+	// Verify compression actually happened (compressed should be smaller)
+	if len(compressedData) >= len(testData) {
+		t.Logf("compressed size (%d) >= original size (%d) - data may be too small for compression",
+			len(compressedData), len(testData))
+	}
+}
+
+func TestCompressDriver_Write(t *testing.T) {
+	testData := []byte("Test data for compression and decompression roundtrip")
+	
+	conf := &config.CompressConfig{Level: 3}
+	driver := NewCompress(conf)
+	
+	// First compress the data
+	originalReader := bytes.NewReader(testData)
+	compressedReader, err := driver.Read(originalReader)
+	if err != nil {
+		t.Fatalf("failed to create compressed reader: %v", err)
+	}
+	
+	compressedData, err := io.ReadAll(compressedReader)
+	if err != nil {
+		t.Fatalf("failed to read compressed data: %v", err)
+	}
+	
+	// Now decompress using Write
+	var output bytes.Buffer
+	decompressWriter, err := driver.Write(&output)
+	if err != nil {
+		t.Fatalf("failed to create decompress writer: %v", err)
+	}
+	
+	_, err = decompressWriter.Write(compressedData)
+	if err != nil {
+		t.Fatalf("failed to write compressed data: %v", err)
+	}
+	
+	// Close to flush
+	if closer, ok := decompressWriter.(io.Closer); ok {
+		err = closer.Close()
+		if err != nil {
+			t.Fatalf("failed to close decompress writer: %v", err)
+		}
+	}
+	
+	decompressedData := output.Bytes()
+	if !bytes.Equal(decompressedData, testData) {
+		t.Errorf("decompressed data doesn't match original:\noriginal: %s\ndecompressed: %s",
+			testData, decompressedData)
+	}
+}
+
+func TestCompressDriver_encoderLevel(t *testing.T) {
+	tests := []struct {
+		level    int
+		expected string
+	}{
+		{1, "fastest"},
+		{2, "fastest"},
+		{3, "default"},
+		{5, "default"},
+		{6, "better"},
+		{9, "better"},
+		{10, "best"},
+		{22, "best"},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			conf := &config.CompressConfig{Level: tt.level}
+			driver := &CompressDriver{Conf: conf}
+			
+			level := driver.encoderLevel()
+			
+			// Compare string representation
+			got := level.String()
+			if got != tt.expected {
+				t.Errorf("level %d: expected %s, got %s", tt.level, tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestCompressDriver_RoundTrip(t *testing.T) {
+	// Test various data sizes
+	testCases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "small",
+			data: []byte("small"),
+		},
+		{
+			name: "medium",
+			data: bytes.Repeat([]byte("medium data "), 100),
+		},
+		{
+			name: "large",
+			data: bytes.Repeat([]byte("large data with some variation "), 1000),
+		},
+		{
+			name: "binary",
+			data: func() []byte {
+				b := make([]byte, 1024)
+				for i := range b {
+					b[i] = byte(i % 256)
+				}
+				return b
+			}(),
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &config.CompressConfig{Level: 3}
+			driver := NewCompress(conf)
+			
+			// Compress
+			originalReader := bytes.NewReader(tc.data)
+			compressedReader, err := driver.Read(originalReader)
+			if err != nil {
+				t.Fatalf("failed to create compressed reader: %v", err)
+			}
+			
+			compressedData, err := io.ReadAll(compressedReader)
+			if err != nil {
+				t.Fatalf("failed to read compressed data: %v", err)
+			}
+			
+			// Decompress
+			var output bytes.Buffer
+			decompressWriter, err := driver.Write(&output)
+			if err != nil {
+				t.Fatalf("failed to create decompress writer: %v", err)
+			}
+			
+			_, err = decompressWriter.Write(compressedData)
+			if err != nil {
+				t.Fatalf("failed to write compressed data: %v", err)
+			}
+			
+			if closer, ok := decompressWriter.(io.Closer); ok {
+				err = closer.Close()
+				if err != nil {
+					t.Fatalf("failed to close decompress writer: %v", err)
+				}
+			}
+			
+			decompressedData := output.Bytes()
+			if !bytes.Equal(decompressedData, tc.data) {
+				t.Errorf("decompressed data doesn't match original (len=%d vs len=%d)",
+					len(decompressedData), len(tc.data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add compression stage using zstd algorithm for backup and restore operations.

Changes:
- Add CompressConfig with configurable compression level (1-22)
- Add CompressDriver implementing the Middleware interface  
- Register compress stage in container.go
- Add comprehensive unit tests

The compression follows the same middleware pattern as encryption:
- Read(): compresses data during backup (zfs send -> compress -> upload)
- Write(): decompresses data during restore (download -> decompress -> zfs receive)

Default compression level is 3 (good balance of speed/ratio).
Levels are mapped to zstd encoder levels:
  1-2: SpeedFastest
  3-5: SpeedDefault
  6-9: SpeedBetterCompression
  10-22: SpeedBestCompression

Closes #211